### PR TITLE
Improve error on cli

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -29,7 +29,7 @@ TOML Example
 
 			res := toml.Get(query)
 			if res == nil {
-				return fmt.Errorf("Not exist data")
+				return fmt.Errorf("Key %v does not exist in %v", query, path)
 			}
 
 			fmt.Println(res)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
-
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +12,7 @@ func GetRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "toml-cli",
 		Short: "toml-cli",
+		SilenceUsage: true,
 		Long: `A simple CLI for editing and querying TOML files.
 	`,
 	}
@@ -29,7 +28,6 @@ func init() {
 // Execute commands
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Improved error printed when a key isn't found in a given toml from

```
> ./toml-cli get sample/example.toml owner.nam
Error: Not exist data
Usage:
  toml-cli get [path] [query] [flags]

Flags:
  -h, --help   help for get

Not exist data
```

to 

```
> ./toml-cli get sample/example.toml owner.nam
Error: Key owner.nam does not exist in sample/example.toml
```
which is much more clear and reflective of the issue at hand and isn't reprinted multiple times.


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [ ] Linked to github-issue with discussion. - no related issue 
- [ ] Wrote tests. - Only change in CLI error output
- [x] rereviewed `Files changed` in the github PR explorer
______
